### PR TITLE
Use correct write buffer size constant

### DIFF
--- a/src/LibUsbSharp/UsbInterface.cs
+++ b/src/LibUsbSharp/UsbInterface.cs
@@ -162,7 +162,7 @@ public sealed class UsbInterface : IUsbInterface
         try
         {
             CheckDisposed();
-            var bufferLength = Math.Min(count, ReadBufferSize);
+            var bufferLength = Math.Min(count, WriteBufferSize);
             lock (_bulkWriteLock)
             {
                 Array.Copy(buffer, _bulkWriteBuffer, bufferLength);


### PR DESCRIPTION
Since both the ReadBufferSize and WriteBufferSize constants are currently set to 32KB, using the incorrect constant caused no issues.