### PR TITLE
UsbInterface BulkRead/Write overloads and optimizations

### DIFF
--- a/src/LibUsbSharp/IUsbInterface.cs
+++ b/src/LibUsbSharp/IUsbInterface.cs
@@ -27,7 +27,7 @@ public interface IUsbInterface : IDisposable
     /// received or the optional timeout is reached. Under the hood it submits a libusb transfer,
     /// then waits for the transfer completed, timeout or error callback to be received.
     /// </summary>
-    /// <param name="buffer">An output buffer for read bytes</param>
+    /// <param name="destination">A destination buffer for read bytes</param>
     /// <param name="bytesRead">The number of bytes read</param>
     /// <param name="timeout">An optional timeout for the read operation</param>
     /// <exception cref="ArgumentException">Thrown when timeout is invalid</exception>
@@ -45,14 +45,20 @@ public interface IUsbInterface : IDisposable
     /// Overflow = The device sent more data than requested.<br />
     /// Interrupted = The read operation was cancelled.<br />
     /// </returns>
-    LibUsbResult BulkRead(byte[] buffer, out int bytesRead, int timeout = -1);
+    LibUsbResult BulkRead(byte[] destination, out int bytesRead, int timeout = Timeout.Infinite);
+
+    LibUsbResult BulkRead(
+        Span<byte> destination,
+        out int bytesRead,
+        int timeout = Timeout.Infinite
+    );
 
     /// <summary>
     /// Bulk write data to the USB device interface. This method blocks until a chunk of data has
     /// been written or the timeout is reached. Under the hood it submits a libusb transfer, then
     /// waits for the transfer completed, timeout or error callback to be received.
     /// </summary>
-    /// <param name="buffer">A buffer of data to write</param>
+    /// <param name="source">A source buffer of data to write</param>
     /// <param name="count">The maximum number of bytes to write</param>
     /// <param name="bytesWritten">The number of bytes written</param>
     /// <param name="timeout">A timeout for the write operation</param>
@@ -74,5 +80,23 @@ public interface IUsbInterface : IDisposable
     /// Interrupted = The write operation was cancelled.<br />
     /// NotSupported = The transfer flags are not supported by the operating system.<br />
     /// </returns>
-    LibUsbResult BulkWrite(byte[] buffer, int count, out int bytesWritten, int timeout);
+    LibUsbResult BulkWrite(
+        byte[] source,
+        int count,
+        out int bytesWritten,
+        int timeout = Timeout.Infinite
+    );
+
+    LibUsbResult BulkWrite(
+        ReadOnlySpan<byte> source,
+        out int bytesWritten,
+        int timeout = Timeout.Infinite
+    );
+
+    LibUsbResult BulkWrite(
+        ReadOnlySpan<byte> source,
+        int count,
+        out int bytesWritten,
+        int timeout = Timeout.Infinite
+    );
 }

--- a/src/LibUsbSharp/UsbInterface.cs
+++ b/src/LibUsbSharp/UsbInterface.cs
@@ -227,7 +227,7 @@ public sealed class UsbInterface : IUsbInterface
         }
 
         // Create a reset event for the transfer callback
-        var transferCompleteEvent = new ManualResetEvent(false);
+        using var transferCompleteEvent = new ManualResetEvent(false);
         var transferStatus = LibUsbTransferStatus.Error;
         var transferLength = 0;
 

--- a/src/LibUsbSharp/UsbInterface.cs
+++ b/src/LibUsbSharp/UsbInterface.cs
@@ -102,17 +102,18 @@ public sealed class UsbInterface : IUsbInterface
         }
     }
 
-    //public LibUsbError Read(ReadOnlySpan<byte> buffer, int timeout, out int transferLength) { }
+    public LibUsbResult BulkRead(byte[] destination, out int bytesRead, int timeout) =>
+        BulkRead(destination.AsSpan(), out bytesRead, timeout);
 
     /// <inheritdoc />
-    public LibUsbResult BulkRead(byte[] buffer, out int bytesRead, int timeout = Timeout.Infinite)
+    public LibUsbResult BulkRead(Span<byte> destination, out int bytesRead, int timeout)
     {
         CheckTransferTimeout(timeout);
         _disposeLock.EnterReadLock(); // Use read lock for reads and writes, to support duplex
         try
         {
             CheckDisposed();
-            var bufferLength = Math.Min(buffer.Length, ReadBufferSize);
+            var bufferLength = Math.Min(destination.Length, ReadBufferSize);
             lock (_bulkReadLock)
             {
                 var result = Transfer(
@@ -123,7 +124,10 @@ public sealed class UsbInterface : IUsbInterface
                     out _lastReadTransfer,
                     out bytesRead
                 );
-                Array.Copy(_bulkReadBuffer, buffer, bytesRead);
+                if (bytesRead > 0)
+                {
+                    _bulkReadBuffer.AsSpan(0, bytesRead).CopyTo(destination);
+                }
                 return result;
             }
         }
@@ -144,12 +148,21 @@ public sealed class UsbInterface : IUsbInterface
         }
     }
 
-    //public LibUsbError Write(ReadOnlySpan<byte> buffer, int timeout, out int transferLength) { }
+    public LibUsbResult BulkWrite(byte[] source, int count, out int bytesWritten, int timeout) =>
+        BulkWrite(source.AsSpan(), count, out bytesWritten, timeout);
+
+    public LibUsbResult BulkWrite(ReadOnlySpan<byte> source, out int bytesWritten, int timeout) =>
+        BulkWrite(source, source.Length, out bytesWritten, timeout);
 
     /// <inheritdoc />
-    public LibUsbResult BulkWrite(byte[] buffer, int count, out int bytesWritten, int timeout)
+    public LibUsbResult BulkWrite(
+        ReadOnlySpan<byte> source,
+        int count,
+        out int bytesWritten,
+        int timeout
+    )
     {
-        if (count > buffer.Length)
+        if (count > source.Length)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(count),
@@ -165,7 +178,7 @@ public sealed class UsbInterface : IUsbInterface
             var bufferLength = Math.Min(count, WriteBufferSize);
             lock (_bulkWriteLock)
             {
-                Array.Copy(buffer, _bulkWriteBuffer, bufferLength);
+                source[..bufferLength].CopyTo(_bulkWriteBuffer.AsSpan(0, bufferLength));
                 return Transfer(
                     _writeEndpoint.Value.EndpointAddress,
                     _bulkWriteBufferHandle,

--- a/src/LibUsbSharp/UsbInterface.cs
+++ b/src/LibUsbSharp/UsbInterface.cs
@@ -28,8 +28,8 @@ public sealed class UsbInterface : IUsbInterface
     private readonly ReaderWriterLockSlim _disposeLock = new();
     private LibUsbTransfer? _lastReadTransfer;
     private LibUsbTransfer? _lastWriteTransfer;
-    private bool _disposing;
-    private bool _disposed;
+    private volatile bool _disposing;
+    private volatile bool _disposed;
 
     /// <inheritdoc />
     public byte Number => _descriptor.InterfaceNumber;

--- a/src/LibUsbSharp/UsbInterface.cs
+++ b/src/LibUsbSharp/UsbInterface.cs
@@ -63,12 +63,16 @@ public sealed class UsbInterface : IUsbInterface
         _bulkReadBuffer = new byte[ReadBufferSize];
         _bulkReadBufferHandle = GCHandle.Alloc(_bulkReadBuffer, GCHandleType.Pinned);
         _readEndpoint = readEndpoint is null
-            ? new Lazy<IUsbEndpointDescriptor>(GetEndpoint(descriptor, UsbEndpointDirection.Input))
+            ? new Lazy<IUsbEndpointDescriptor>(() =>
+                GetEndpoint(descriptor, UsbEndpointDirection.Input)
+            )
             : new Lazy<IUsbEndpointDescriptor>(readEndpoint);
         _bulkWriteBuffer = new byte[WriteBufferSize];
         _bulkWriteBufferHandle = GCHandle.Alloc(_bulkWriteBuffer, GCHandleType.Pinned);
         _writeEndpoint = writeEndpoint is null
-            ? new Lazy<IUsbEndpointDescriptor>(GetEndpoint(descriptor, UsbEndpointDirection.Output))
+            ? new Lazy<IUsbEndpointDescriptor>(() =>
+                GetEndpoint(descriptor, UsbEndpointDirection.Output)
+            )
             : new Lazy<IUsbEndpointDescriptor>(writeEndpoint);
     }
 


### PR DESCRIPTION
- Add UsbInterface read/write overloads using spans instead of byte[] arrays
- Make _disposing and _disposed variables volatile to avoid stale reads
- Fix issue: make get read/write endpoint truly lazy
- Fix issue: ManualResetEvent not disposed to avoid handle leaks in long-running processes