### PR TITLE
Fix race in ReadStringDescriptorCached

### DIFF
--- a/src/LibUsbSharp/UsbDevice.cs
+++ b/src/LibUsbSharp/UsbDevice.cs
@@ -69,7 +69,7 @@ public sealed class UsbDevice : IUsbDevice
             var value = ReadStringDescriptor(descriptorIndex);
             if (!string.IsNullOrWhiteSpace(value))
             {
-                _ = _descriptorCache.TryAdd(descriptorIndex, value);
+                _descriptorCache[descriptorIndex] = value;
             }
             return value;
         }


### PR DESCRIPTION
Fix issue discovered by @superstian during code review. A race in ReadStringDescriptorCached may result a cache miss and redundant reads.