### PR TITLE
Require device with class VendorSpecific interface

### DIFF
--- a/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
@@ -60,7 +60,7 @@ public sealed class Given_a_vendor_class_USB_device : IDisposable
     public void Open_interfaces_are_auto_disposed_when_UsbDevice_is_disposed()
     {
         // Open device and leave it open
-        var device = _deviceSource.OpenUsbDeviceOrSkip();
+        var device = _deviceSource.OpenUsbDeviceOrSkip(UsbClass.VendorSpecific);
         // Claim interface without disposing it
         _ = device.ClaimInterface(UsbClass.VendorSpecific);
         // Dispose device


### PR DESCRIPTION
for interface dispose test. The test requires a device with this interface class and will fail intead of skip when such device is not present.