### PR TITLE
Refactor LibUsb initialization

### DIFF
--- a/src/LibUsbSharp/ILibUsb.cs
+++ b/src/LibUsbSharp/ILibUsb.cs
@@ -6,13 +6,6 @@ namespace LibUsbSharp;
 public interface ILibUsb : IDisposable
 {
     /// <summary>
-    /// Initialized the LibUsb library, attaches log callback and starts the
-    /// background thread that handles LibUsb events and drives async transfers.
-    /// </summary>
-    /// <param name="logLevel">The desired LibUsb library log level.</param>
-    void Initialize(LogLevel logLevel = LogLevel.Warning);
-
-    /// <summary>
     /// Hotplug events are supported on macOS, Linux and Windows.
     /// https://libusb.sourceforge.io/api-1.0/libusb_hotplug.html
     /// </summary>

--- a/tests/LibUsbSharp.Tests/Given_a_supported_Huddly_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_a_supported_Huddly_USB_device.cs
@@ -16,8 +16,7 @@ public sealed class Given_a_supported_Huddly_USB_device : IDisposable
     {
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_a_supported_Huddly_USB_device>();
-        _libUsb = new LibUsb(_loggerFactory);
-        _libUsb.Initialize(LogLevel.Information);
+        _libUsb = LibUsb.Initialize(_loggerFactory, LogLevel.Information);
         _deviceSource = new TestDeviceSource(_logger, _libUsb);
         _deviceSource.SetRequiredVendorId(HuddlyVendorId);
         _deviceSource.SetRequiredInterfaceClass(

--- a/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_a_vendor_class_USB_device.cs
@@ -14,8 +14,7 @@ public sealed class Given_a_vendor_class_USB_device : IDisposable
     {
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_a_vendor_class_USB_device>();
-        _libUsb = new LibUsb(_loggerFactory);
-        _libUsb.Initialize(LogLevel.Information);
+        _libUsb = LibUsb.Initialize(_loggerFactory, LogLevel.Information);
         _deviceSource = new TestDeviceSource(_logger, _libUsb);
         _deviceSource.SetPreferredVendorId(0x2BD9);
         _deviceSource.SetRequiredInterfaceClass(

--- a/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_any_USB_device.cs
@@ -15,8 +15,7 @@ public sealed class Given_any_USB_device : IDisposable
     {
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_any_USB_device>();
-        _libUsb = new LibUsb(_loggerFactory);
-        _libUsb.Initialize(LogLevel.Information);
+        _libUsb = LibUsb.Initialize(_loggerFactory, LogLevel.Information);
         _deviceSource = new TestDeviceSource(_logger, _libUsb);
         _deviceSource.SetPreferredVendorId(0x2BD9);
     }

--- a/tests/LibUsbSharp.Tests/Given_no_USB_device.cs
+++ b/tests/LibUsbSharp.Tests/Given_no_USB_device.cs
@@ -20,41 +20,23 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void Creating_two_active_instances_of_LibUsb_is_not_allowed()
     {
-        using var libUsb1 = new LibUsb(_loggerFactory);
-        var act = () => new LibUsb(_loggerFactory);
+        using var libUsb1 = LibUsb.Initialize(_loggerFactory);
+        var act = () => LibUsb.Initialize(_loggerFactory);
         act.Should().Throw<InvalidOperationException>().WithMessage("Only one LibUsb instance allowed.");
     }
 
     [Fact]
     public void Creating_a_second_instance_of_LibUsb_is_allowed_after_disposal_of_first()
     {
-        var libUsb1 = new LibUsb(_loggerFactory);
+        var libUsb1 = LibUsb.Initialize(_loggerFactory);
         libUsb1.Dispose();
-        using var libUsb2 = new LibUsb(_loggerFactory);
-    }
-
-    [Fact]
-    public void Initialize_throws_when_called_a_second_time()
-    {
-        using var libUsb = new LibUsb(_loggerFactory);
-        libUsb.Initialize();
-        var act = () => libUsb.Initialize();
-        act.Should().Throw<InvalidOperationException>().WithMessage("libusb-1.0 already initialized.");
-    }
-
-    [Fact]
-    public void GetDeviceList_throws_when_called_without_Initialize()
-    {
-        using var libUsb = new LibUsb(_loggerFactory);
-        var act = () => libUsb.GetDeviceList();
-        act.Should().Throw<InvalidOperationException>();
+        using var libUsb2 = LibUsb.Initialize(_loggerFactory);
     }
 
     [Fact]
     public void GetDeviceList_throws_when_called_after_Dispose()
     {
-        using var libUsb = new LibUsb(_loggerFactory);
-        libUsb.Initialize(LogLevel.Information);
+        using var libUsb = LibUsb.Initialize(_loggerFactory, LogLevel.Information);
         libUsb.Dispose();
         var act = () => libUsb.GetDeviceList();
         act.Should().Throw<ObjectDisposedException>();
@@ -67,7 +49,7 @@ public sealed class Given_no_USB_device : IDisposable
         {
             return;
         }
-        using var libUsb = new LibUsb(_loggerFactory);
+        using var libUsb = LibUsb.Initialize(_loggerFactory);
         var act = () => libUsb.RegisterHotplug(vendorId: 0x2BD9);
         act.Should().Throw<InvalidOperationException>();
     }
@@ -79,8 +61,7 @@ public sealed class Given_no_USB_device : IDisposable
         {
             return;
         }
-        using var libUsb = new LibUsb(_loggerFactory);
-        libUsb.Initialize(LogLevel.Information);
+        using var libUsb = LibUsb.Initialize(_loggerFactory, LogLevel.Information);
         var success = libUsb.RegisterHotplug(vendorId: 0x2BD9);
         success.Should().BeTrue();
     }
@@ -92,8 +73,7 @@ public sealed class Given_no_USB_device : IDisposable
         {
             return;
         }
-        using var libUsb = new LibUsb(_loggerFactory);
-        libUsb.Initialize(LogLevel.Information);
+        using var libUsb = LibUsb.Initialize(_loggerFactory, LogLevel.Information);
         var success = libUsb.RegisterHotplug(vendorId: 0x2BD9);
         success.Should().BeFalse();
     }


### PR DESCRIPTION
Makes LibUsb.Initialize static and the only way to get a LibUsb instance. This has several adavantages:
* You can't have an instance of LibUsb which is not in valid/initialized state
* You can't call initialize on an already initialized object
* Because initialization is static and a LibUsb instance is guaranteed to have a valid context, the `GetInitializedContextOrThrow()` method and a couple of the tests are now obsolete and logic can be simplified

The event thread creation is moved to the constructor now. An alternative is to create it in the static initializer and pass it to the constructor like we do with the context. This is really how I want to do it, but I didn't want to introduce too many changes in this PR.