### PR TITLE
Map LIBUSB_TRANSFER_STALL to LIBUSB_ERROR_PIPE

### DIFF
--- a/src/UsbDotNet.Extensions/ControlTransfer/UsbDeviceExtension.cs
+++ b/src/UsbDotNet.Extensions/ControlTransfer/UsbDeviceExtension.cs
@@ -1,4 +1,4 @@
-﻿using UsbDotNet.Core;
+using UsbDotNet.Core;
 using UsbDotNet.Transfer;
 
 namespace UsbDotNet.Extensions.ControlTransfer;
@@ -18,15 +18,19 @@ public static class UsbDeviceExtension
     /// <param name="timeout">Timeout before giving up due to no response being received</param>
     /// <exception cref="ArgumentException">Thrown when the destination buffer is too large.</exception>
     /// <returns>
-    /// Success = The read operation completed successfully.<br />
-    /// IO = The read operation failed.<br />
-    /// InvalidParameter = Transfer size is larger than OS or hardware can support.<br />
-    /// NoDevice = The device has been disconnected.<br />
-    /// ResourceBusy = Halt condition detected (endpoint stalled) or control request not supported.<br />
-    /// Timeout = The read operation timed out.<br />
-    /// Overflow = The device sent more data than expected.<br />
-    /// Interrupted = The read operation was canceled.<br />
-    /// NotSupported = The transfer flags are not supported by the operating system.<br />
+    /// <list>
+    /// <item>Success = The read operation completed successfully.</item>
+    /// <item>IO = The read operation failed.</item>
+    /// <item>InvalidParameter = Transfer size is larger than OS or hardware can support.</item>
+    /// <item>NoDevice = The device has been disconnected.</item>
+    /// <item>
+    /// PipeError = Halt condition detected (endpoint stalled) or control request not supported.
+    /// </item>
+    /// <item>Timeout = The read operation timed out.</item>
+    /// <item>Overflow = The device sent more data than expected.</item>
+    /// <item>Interrupted = The read operation was canceled.</item>
+    /// <item>NotSupported = The transfer flags are not supported by the operating system.</item>
+    /// </list>
     /// </returns>
     public static UsbResult ControlRead(
         this IUsbDevice device,
@@ -62,15 +66,19 @@ public static class UsbDeviceExtension
     /// <param name="timeout">Timeout before giving up due to no response being received</param>
     /// <exception cref="ArgumentException">Thrown when the source payload is too large.</exception>
     /// <returns>
-    /// Success = The write operation completed successfully.<br />
-    /// IO = The write operation failed.<br />
-    /// InvalidParameter = Transfer size is larger than OS or hardware can support.<br />
-    /// NoDevice = The device has been disconnected.<br />
-    /// ResourceBusy = Halt condition detected (endpoint stalled) or control request not supported.<br />
-    /// Timeout = The write operation timed out.<br />
-    /// Overflow = The host sent more data than expected.<br />
-    /// Interrupted = The write operation was canceled.<br />
-    /// NotSupported = The transfer flags are not supported by the operating system.<br />
+    /// <list>
+    /// <item>Success = The write operation completed successfully.</item>
+    /// <item>IO = The write operation failed.</item>
+    /// <item>InvalidParameter = Transfer size is larger than OS or hardware can support.</item>
+    /// <item>NoDevice = The device has been disconnected.</item>
+    /// <item>
+    /// PipeError = Halt condition detected (endpoint stalled) or control request not supported.
+    /// </item>
+    /// <item>Timeout = The write operation timed out.</item>
+    /// <item>Overflow = The host sent more data than expected.</item>
+    /// <item>Interrupted = The write operation was canceled.</item>
+    /// <item>NotSupported = The transfer flags are not supported by the operating system.</item>
+    /// </list>
     /// </returns>
     public static UsbResult ControlWrite(
         this IUsbDevice device,

--- a/src/UsbDotNet/IUsbDevice.cs
+++ b/src/UsbDotNet/IUsbDevice.cs
@@ -70,6 +70,7 @@ public interface IUsbDevice : IDisposable
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when the destination buffer is too large.
     /// </exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the UsbDevice is disposed.</exception>
     /// <returns>
     /// <list>
     /// <item>Success = The read operation completed successfully.</item>
@@ -77,7 +78,7 @@ public interface IUsbDevice : IDisposable
     /// <item>InvalidParameter = Transfer size is larger than OS or hardware can support.</item>
     /// <item>NoDevice = The device has been disconnected.</item>
     /// <item>
-    /// ResourceBusy = Halt condition detected (endpoint stalled) or control request not supported.
+    /// PipeError = Halt condition detected (endpoint stalled) or control request not supported.
     /// </item>
     /// <item>Timeout = The read operation timed out.</item>
     /// <item>Overflow = The device sent more data than expected.</item>
@@ -110,6 +111,7 @@ public interface IUsbDevice : IDisposable
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when the source payload is too large.
     /// </exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the UsbDevice is disposed.</exception>
     /// <returns>
     /// <list>
     /// <item>Success = The write operation completed successfully.</item>
@@ -117,7 +119,7 @@ public interface IUsbDevice : IDisposable
     /// <item>InvalidParameter = Transfer size is larger than OS or hardware can support.</item>
     /// <item>NoDevice = The device has been disconnected.</item>
     /// <item>
-    /// ResourceBusy = Halt condition detected (endpoint stalled) or control request not supported.
+    /// PipeError = Halt condition detected (endpoint stalled) or control request not supported.
     /// </item>
     /// <item>Timeout = The write operation timed out.</item>
     /// <item>Overflow = The host sent more data than expected.</item>

--- a/src/UsbDotNet/IUsbInterface.cs
+++ b/src/UsbDotNet/IUsbInterface.cs
@@ -45,9 +45,7 @@ public interface IUsbInterface : IDisposable
     /// <item>IO = The read operation failed.</item>
     /// <item>InvalidParameter = Transfer size is larger than OS or hardware can support.</item>
     /// <item>NoDevice = The device has been disconnected.</item>
-    /// <item>
-    /// PipeError = Halt condition detected (endpoint stalled) or control request not supported.
-    /// </item>
+    /// <item>PipeError = Halt condition detected (endpoint stalled).</item>
     /// <item>Timeout = The read operation timed out.</item>
     /// <item>Overflow = The device sent more data than expected.</item>
     /// <item>Interrupted = The read operation was canceled.</item>
@@ -75,9 +73,7 @@ public interface IUsbInterface : IDisposable
     /// <item>IO = The write operation failed.</item>
     /// <item>InvalidParameter = Transfer size is larger than OS or hardware can support.</item>
     /// <item>NoDevice = The device has been disconnected.</item>
-    /// <item>
-    /// PipeError = Halt condition detected (endpoint stalled) or control request not supported.
-    /// </item>
+    /// <item>PipeError = Halt condition detected (endpoint stalled).</item>
     /// <item>Timeout = The write operation timed out.</item>
     /// <item>Overflow = The host sent more data than expected.</item>
     /// <item>Interrupted = The write operation was canceled.</item>

--- a/src/UsbDotNet/IUsbInterface.cs
+++ b/src/UsbDotNet/IUsbInterface.cs
@@ -46,7 +46,7 @@ public interface IUsbInterface : IDisposable
     /// <item>InvalidParameter = Transfer size is larger than OS or hardware can support.</item>
     /// <item>NoDevice = The device has been disconnected.</item>
     /// <item>
-    /// ResourceBusy = Halt condition detected (endpoint stalled) or control request not supported.
+    /// PipeError = Halt condition detected (endpoint stalled) or control request not supported.
     /// </item>
     /// <item>Timeout = The read operation timed out.</item>
     /// <item>Overflow = The device sent more data than expected.</item>
@@ -76,7 +76,7 @@ public interface IUsbInterface : IDisposable
     /// <item>InvalidParameter = Transfer size is larger than OS or hardware can support.</item>
     /// <item>NoDevice = The device has been disconnected.</item>
     /// <item>
-    /// ResourceBusy = Halt condition detected (endpoint stalled) or control request not supported.
+    /// PipeError = Halt condition detected (endpoint stalled) or control request not supported.
     /// </item>
     /// <item>Timeout = The write operation timed out.</item>
     /// <item>Overflow = The host sent more data than expected.</item>

--- a/src/UsbDotNet/Internal/Transfer/LibUsbTransferStatusExtension.cs
+++ b/src/UsbDotNet/Internal/Transfer/LibUsbTransferStatusExtension.cs
@@ -12,7 +12,7 @@ internal static class LibUsbTransferStatusExtension
             libusb_transfer_status.LIBUSB_TRANSFER_TIMED_OUT => libusb_error.LIBUSB_ERROR_TIMEOUT,
             libusb_transfer_status.LIBUSB_TRANSFER_CANCELLED =>
                 libusb_error.LIBUSB_ERROR_INTERRUPTED,
-            libusb_transfer_status.LIBUSB_TRANSFER_STALL => libusb_error.LIBUSB_ERROR_BUSY,
+            libusb_transfer_status.LIBUSB_TRANSFER_STALL => libusb_error.LIBUSB_ERROR_PIPE,
             libusb_transfer_status.LIBUSB_TRANSFER_NO_DEVICE => libusb_error.LIBUSB_ERROR_NO_DEVICE,
             libusb_transfer_status.LIBUSB_TRANSFER_OVERFLOW => libusb_error.LIBUSB_ERROR_OVERFLOW,
         };


### PR DESCRIPTION
Map LIBUSB_TRANSFER_STALL to LIBUSB_ERROR_PIPE not LIBUSB_ERROR_BUSY. LIBUSB_ERROR_PIPE is more correct, TRANSFER_STALL is an indication of an error condition that will not clear by itself. Returning LIBUSB_ERROR_PIPE on TRANSFER_STALL also matches libusb's own handling/mapping of errors in the sync APIs.