### PR TITLE
Lower level of some very verbose libusb device enum logs

### DIFF
--- a/src/UsbDotNet/IUsb.cs
+++ b/src/UsbDotNet/IUsb.cs
@@ -15,9 +15,9 @@ public interface IUsb : IDisposable
     /// Initializes the USB library (libusb), attaches a log callback and starts the
     /// background thread that handles USB events and drives async transfers.
     /// </summary>
-    /// <param name="logLevel">The desired USB library (libusb) log level.</param>
+    /// <param name="nativeLibraryLogLevel">The desired log level for the libusb native library.</param>
     /// <exception cref="ObjectDisposedException">Thrown when the Usb type is disposed.</exception>
-    void Initialize(LogLevel logLevel = LogLevel.Warning);
+    void Initialize(LogLevel nativeLibraryLogLevel = LogLevel.Warning);
 
     /// <summary>
     /// Hotplug events are supported on macOS, Linux and Windows.

--- a/src/UsbDotNet/Internal/LibUsbLogHandler.cs
+++ b/src/UsbDotNet/Internal/LibUsbLogHandler.cs
@@ -85,8 +85,24 @@ internal static class LibUsbLogHandler
     private static bool LogAsDebugOverride(libusb_log_level level, string message) =>
         IsWindows
         && (
-            // Frequent when devices are disconnected during enumeration on Windows
+            // Very frequent on some systems during device enumeration on Windows
             (
+                level is libusb_log_level.LIBUSB_LOG_LEVEL_INFO
+                && message.StartsWith(
+                    "libusb: info [winusb_get_device_list] The following device has no driver:",
+                    StringComparison.Ordinal
+                )
+            )
+            // Very frequent on some systems during device enumeration on Windows
+            || (
+                level is libusb_log_level.LIBUSB_LOG_LEVEL_WARNING
+                && message.StartsWith(
+                    "libusb: warning [set_composite_interface] failure to read interface number for",
+                    StringComparison.Ordinal
+                )
+            )
+            // Frequent when devices are disconnected during enumeration on Windows
+            || (
                 level is libusb_log_level.LIBUSB_LOG_LEVEL_WARNING
                 && message.StartsWith(
                     "libusb: warning [winusb_get_device_list] could not detect installation state of driver for",

--- a/src/UsbDotNet/Usb.cs
+++ b/src/UsbDotNet/Usb.cs
@@ -72,7 +72,7 @@ public sealed class Usb : IUsb
     }
 
     /// <inheritdoc/>
-    public void Initialize(LogLevel logLevel = LogLevel.Warning)
+    public void Initialize(LogLevel nativeLibraryLogLevel = LogLevel.Warning)
     {
         lock (_lock)
         {
@@ -85,7 +85,7 @@ public sealed class Usb : IUsb
             _context = _libUsb.CreateContext();
             _logger.LogInformation("LibUsb v{LibUsbVersion} initialized.", GetVersion());
 
-            InitializeLibUsbLogHandler(_context, logLevel);
+            InitializeLibUsbLogHandler(_context, nativeLibraryLogLevel);
             _eventLoop = new LibUsbEventLoop(_loggerFactory, _context);
             _eventLoop.Start();
         }


### PR DESCRIPTION
Adjusts libusb logging to reduce noisy device-enumeration output (especially on Windows) while keeping the rest of the USB wrapper behavior unchanged.