### PR TITLE
Improve UsbDotNet Dependency Injection support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,27 @@ jobs:
           --no-restore \
           --runtime ${{ matrix.config.runtime }}
 
+    - name: Build UsbDotNet.DeviceInteractionSample
+      shell: bash
+      run: |
+        dotnet build examples/UsbDotNet.DeviceInteractionSample/UsbDotNet.DeviceInteractionSample.csproj \
+          --no-restore \
+          --runtime ${{ matrix.config.runtime }}
+
+    - name: Build UsbDotNet.LibUsbNative.DeviceListToJsonSample
+      shell: bash
+      run: |
+        dotnet build examples/UsbDotNet.LibUsbNative.DeviceListToJsonSample/UsbDotNet.LibUsbNative.DeviceListToJsonSample.csproj \
+          --no-restore \
+          --runtime ${{ matrix.config.runtime }}
+
+    - name: Build UsbDotNet.LibUsbNative.DeviceListToStringSample
+      shell: bash
+      run: |
+        dotnet build examples/UsbDotNet.LibUsbNative.DeviceListToStringSample/UsbDotNet.LibUsbNative.DeviceListToStringSample.csproj \
+          --no-restore \
+          --runtime ${{ matrix.config.runtime }}
+
     - name: Build UsbDotNet.LibUsbNative.Tests
       shell: bash
       run: |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,12 +26,30 @@
         <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+        <PackageVersion
+            Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+            Version="8.0.2"
+        />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+        <PackageVersion
+            Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+            Version="10.0.2"
+        />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+        <PackageVersion
+            Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+            Version="10.0.3"
+        />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,9 @@
             Include="Microsoft.Extensions.DependencyInjection.Abstractions"
             Version="10.0.3"
         />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
         <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     </ItemGroup>
 </Project>

--- a/UsbDotNet.sln
+++ b/UsbDotNet.sln
@@ -67,6 +67,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{182308
 		tests\UsbDotNet.Tests.Shared\UsbDotNet.Tests.Shared.props = tests\UsbDotNet.Tests.Shared\UsbDotNet.Tests.Shared.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UsbDotNet.DeviceInteractionSample", "examples\UsbDotNet.DeviceInteractionSample\UsbDotNet.DeviceInteractionSample.csproj", "{8F20BCB3-D0FC-C544-E8CB-774875158BA8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -197,6 +199,18 @@ Global
 		{FC957597-AE2B-4F27-6EC6-DBBF5601A2DD}.Release|arm64.Build.0 = Release|arm64
 		{FC957597-AE2B-4F27-6EC6-DBBF5601A2DD}.Release|x64.ActiveCfg = Release|x64
 		{FC957597-AE2B-4F27-6EC6-DBBF5601A2DD}.Release|x64.Build.0 = Release|x64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Debug|Any CPU.Build.0 = Debug|x64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Debug|arm64.ActiveCfg = Debug|arm64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Debug|arm64.Build.0 = Debug|arm64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Debug|x64.ActiveCfg = Debug|x64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Debug|x64.Build.0 = Debug|x64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Release|Any CPU.ActiveCfg = Release|x64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Release|Any CPU.Build.0 = Release|x64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Release|arm64.ActiveCfg = Release|arm64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Release|arm64.Build.0 = Release|arm64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Release|x64.ActiveCfg = Release|x64
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -212,6 +226,7 @@ Global
 		{55A88F4D-C933-85BD-92D3-A8B6B0D1CBC7} = {C4C3F697-DBEA-4E05-8593-C7C2972E1A37}
 		{75A61D89-2A8F-D43C-DB4F-09858614C402} = {C4C3F697-DBEA-4E05-8593-C7C2972E1A37}
 		{182308FD-7AB7-4A24-8BAE-5DD646CD0484} = {D5E2E026-05AB-49B8-A8DB-5DFEF339FDE4}
+		{8F20BCB3-D0FC-C544-E8CB-774875158BA8} = {C4C3F697-DBEA-4E05-8593-C7C2972E1A37}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {90DCAD80-DFC8-4E0E-8E33-E205541FCE94}

--- a/examples/UsbDotNet.DeviceInteractionSample/DeviceInteraction.cs
+++ b/examples/UsbDotNet.DeviceInteractionSample/DeviceInteraction.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using UsbDotNet.Core;
+
+namespace UsbDotNet.DeviceInteractionSample;
+
+internal sealed class DeviceInteraction(
+    IUsb usb,
+    ILogger<DeviceInteraction> logger,
+    IOptions<DeviceInteractionOptions> options
+)
+{
+    public void Run()
+    {
+        usb.Initialize();
+
+        var devices = usb.GetDeviceList(
+            vendorId: options.Value.VendorId,
+            productIds: options.Value.ProductId is { } pid ? [pid] : null
+        );
+
+        logger.LogInformation("Found {Count} matching USB device(s).", devices.Count);
+        foreach (var d in devices)
+        {
+            logger.LogInformation(
+                "VID=0x{VID:X4} PID=0x{PID:X4} Bus={Bus} Addr={Addr}",
+                d.VendorId,
+                d.ProductId,
+                d.BusNumber,
+                d.BusAddress
+            );
+        }
+
+        if (devices.Count == 0)
+            return;
+
+        var first = devices.First();
+        logger.LogInformation("Opening device '{Key}'...", first.DeviceKey);
+        try
+        {
+            using var device = usb.OpenDevice(first.DeviceKey);
+            logger.LogInformation("Manufacturer : {Value}", device.GetManufacturer());
+            logger.LogInformation("Product      : {Value}", device.GetProduct());
+            logger.LogInformation("Serial       : {Value}", device.GetSerialNumber());
+        }
+        catch (UsbException ex)
+        {
+            logger.LogWarning("Failed to open or read from device. {Message}", ex.Message);
+        }
+    }
+}

--- a/examples/UsbDotNet.DeviceInteractionSample/DeviceInteractionOptions.cs
+++ b/examples/UsbDotNet.DeviceInteractionSample/DeviceInteractionOptions.cs
@@ -1,0 +1,7 @@
+namespace UsbDotNet.DeviceInteractionSample;
+
+internal sealed class DeviceInteractionOptions
+{
+    public ushort? VendorId { get; set; }
+    public ushort? ProductId { get; set; }
+}

--- a/examples/UsbDotNet.DeviceInteractionSample/Program.cs
+++ b/examples/UsbDotNet.DeviceInteractionSample/Program.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using UsbDotNet.DeviceInteractionSample;
+
+// Optional CLI args: --vid 0x2BD9 --pid 0x0021
+var vendorFilter = TryParseHex(GetArg(args, "--vid"));
+var productFilter = TryParseHex(GetArg(args, "--pid"));
+
+var builder = Host.CreateApplicationBuilder(args);
+builder
+    .Logging.AddSimpleConsole()
+    .Services.Configure<DeviceInteractionOptions>(o =>
+    {
+        o.VendorId = vendorFilter;
+        o.ProductId = productFilter;
+    })
+    .AddUsbDotNet(o => o.NativeLibraryLogLevel = LogLevel.Warning)
+    .AddSingleton<DeviceInteraction>();
+
+using var host = builder.Build();
+host.Services.GetRequiredService<DeviceInteraction>().Run();
+
+static string? GetArg(string[] args, string name)
+{
+    var idx = Array.IndexOf(args, name);
+    return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
+}
+
+static ushort? TryParseHex(string? value) =>
+    string.IsNullOrEmpty(value) ? null
+    : ushort.TryParse(
+        value.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+            ? value.AsSpan(2)
+            : value.AsSpan(),
+        NumberStyles.HexNumber,
+        provider: null,
+        out var result
+    )
+        ? result
+    : null;

--- a/examples/UsbDotNet.DeviceInteractionSample/UsbDotNet.DeviceInteractionSample.csproj
+++ b/examples/UsbDotNet.DeviceInteractionSample/UsbDotNet.DeviceInteractionSample.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <!-- CA1812: internal types (worker, options) are instantiated via DI / reflection. -->
+        <NoWarn>$(NoWarn);CA1303;CA1812</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\UsbDotNet\UsbDotNet.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/UsbDotNet/IUsb.cs
+++ b/src/UsbDotNet/IUsb.cs
@@ -13,11 +13,23 @@ public interface IUsb : IDisposable
 {
     /// <summary>
     /// Initializes the USB library (libusb), attaches a log callback and starts the
-    /// background thread that handles USB events and drives async transfers.
+    /// background thread that handles USB events and drives async transfers. The libusb
+    /// native log level is read from <see cref="UsbDotNetOptions.NativeLibraryLogLevel"/>
+    /// supplied at construction.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown when the Usb type is disposed.</exception>
+    void Initialize();
+
+    /// <summary>
+    /// Initializes the USB library with an explicit native log level.
     /// </summary>
     /// <param name="nativeLibraryLogLevel">The desired log level for the libusb native library.</param>
     /// <exception cref="ObjectDisposedException">Thrown when the Usb type is disposed.</exception>
-    void Initialize(LogLevel nativeLibraryLogLevel = LogLevel.Warning);
+    [Obsolete(
+        "Configure NativeLibraryLogLevel via UsbDotNetOptions when constructing Usb, and call the"
+            + "parameterless Initialize() instead. This overload will be removed in a future version."
+    )]
+    void Initialize(LogLevel nativeLibraryLogLevel);
 
     /// <summary>
     /// Hotplug events are supported on macOS, Linux and Windows.

--- a/src/UsbDotNet/IUsb.cs
+++ b/src/UsbDotNet/IUsb.cs
@@ -26,7 +26,7 @@ public interface IUsb : IDisposable
     /// <param name="nativeLibraryLogLevel">The desired log level for the libusb native library.</param>
     /// <exception cref="ObjectDisposedException">Thrown when the Usb type is disposed.</exception>
     [Obsolete(
-        "Configure NativeLibraryLogLevel via UsbDotNetOptions when constructing Usb, and call the"
+        "Configure NativeLibraryLogLevel via UsbDotNetOptions when constructing Usb, and call the "
             + "parameterless Initialize() instead. This overload will be removed in a future version."
     )]
     void Initialize(LogLevel nativeLibraryLogLevel);

--- a/src/UsbDotNet/Internal/LibUsbEventLoop.cs
+++ b/src/UsbDotNet/Internal/LibUsbEventLoop.cs
@@ -13,7 +13,6 @@ namespace UsbDotNet.Internal;
 internal sealed class LibUsbEventLoop : IDisposable
 {
     private readonly object _lock = new();
-    private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<LibUsbEventLoop> _logger;
     private readonly ISafeContext _context;
     private readonly CancellationTokenSource _cts;
@@ -21,10 +20,9 @@ internal sealed class LibUsbEventLoop : IDisposable
     private Thread? _thread;
     private bool _disposed;
 
-    public LibUsbEventLoop(ILoggerFactory loggerFactory, ISafeContext context)
+    public LibUsbEventLoop(ILogger<LibUsbEventLoop> logger, ISafeContext context)
     {
-        _loggerFactory = loggerFactory;
-        _logger = _loggerFactory.CreateLogger<LibUsbEventLoop>();
+        _logger = logger;
         _context = context;
         _cts = new CancellationTokenSource();
         _completedPtr = Marshal.AllocHGlobal(sizeof(int));

--- a/src/UsbDotNet/Usb.cs
+++ b/src/UsbDotNet/Usb.cs
@@ -21,6 +21,7 @@ public sealed class Usb : IUsb
     private readonly ILibUsb _libUsb;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<Usb> _logger;
+    private readonly UsbDotNetOptions _options;
     private readonly ConcurrentDictionary<string, UsbDevice> _openDevices = new();
 #pragma warning disable CA2213 // Disposable fields should be disposed
     // CA2213 false positive
@@ -41,7 +42,7 @@ public sealed class Usb : IUsb
     }
 
     /// <summary>
-    /// Creates UsbDotNet with optional LibUsb instance and logging builder.
+    /// Creates UsbDotNet with optional LibUsb instance, logging builder, and options.
     /// Consider using DI; registering via IServiceCollection.AddUsbDotNet() instead.
     /// <para>NOTE: Call Initialize() before enumerating or opening devices.</para>
     /// </summary>
@@ -52,16 +53,23 @@ public sealed class Usb : IUsb
     /// Optional logging builder; e.g. <c>builder =&gt; builder.AddConsole()</c>.
     /// If null, logging is disabled.
     /// </param>
+    /// <param name="configureOptions">
+    /// Optional <see cref="UsbDotNetOptions"/> configurator; e.g.
+    /// <c>options =&gt; options.NativeLibraryLogLevel = LogLevel.Information</c>.
+    /// </param>
     public static Usb Create(
         ILibUsb? libUsb = null,
-        Action<ILoggingBuilder>? configureLogging = null
+        Action<ILoggingBuilder>? configureLogging = null,
+        Action<UsbDotNetOptions>? configureOptions = null
     )
     {
         var provider = new ServiceCollection()
             .AddLogging(configureLogging ?? (_ => { }))
             .BuildServiceProvider();
         var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-        return new Usb(libUsb, loggerFactory, loggerFactory.CreateLogger<Usb>());
+        var options = new UsbDotNetOptions();
+        configureOptions?.Invoke(options);
+        return new Usb(libUsb, loggerFactory, loggerFactory.CreateLogger<Usb>(), options);
     }
 
     /// <summary>
@@ -69,7 +77,12 @@ public sealed class Usb : IUsb
     /// <para>NOTE: Call Initialize() before enumerating or opening devices.</para>
     /// </summary>
     public Usb()
-        : this(libUsb: null, NullLoggerFactory.Instance, NullLogger<Usb>.Instance) { }
+        : this(
+            libUsb: null,
+            NullLoggerFactory.Instance,
+            NullLogger<Usb>.Instance,
+            new UsbDotNetOptions()
+        ) { }
 
     /// <summary>
     /// Creates UsbDotNet with optional LibUsb instance and logging.
@@ -89,10 +102,16 @@ public sealed class Usb : IUsb
         : this(
             libUsb,
             loggerFactory ?? NullLoggerFactory.Instance,
-            (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<Usb>()
+            (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<Usb>(),
+            new UsbDotNetOptions()
         ) { }
 
-    internal Usb(ILibUsb? libUsb, ILoggerFactory loggerFactory, ILogger<Usb> logger)
+    internal Usb(
+        ILibUsb? libUsb,
+        ILoggerFactory loggerFactory,
+        ILogger<Usb> logger,
+        UsbDotNetOptions options
+    )
     {
         if (Interlocked.CompareExchange(ref _instances, 1, 0) != 0)
         {
@@ -105,6 +124,7 @@ public sealed class Usb : IUsb
             _libUsb = libUsb ?? new LibUsb();
             _loggerFactory = loggerFactory;
             _logger = logger;
+            _options = options;
             LibUsbLogHandler.SetLogger(_logger);
         }
         catch (Exception)
@@ -115,7 +135,7 @@ public sealed class Usb : IUsb
     }
 
     /// <inheritdoc/>
-    public void Initialize(LogLevel nativeLibraryLogLevel = LogLevel.Warning)
+    public void Initialize()
     {
         lock (_lock)
         {
@@ -128,13 +148,24 @@ public sealed class Usb : IUsb
             _context = _libUsb.CreateContext();
             _logger.LogInformation("LibUsb v{LibUsbVersion} initialized.", GetVersion());
 
-            InitializeLibUsbLogHandler(_context, nativeLibraryLogLevel);
+            InitializeLibUsbLogHandler(_context, _options.NativeLibraryLogLevel);
             _eventLoop = new LibUsbEventLoop(
                 _loggerFactory.CreateLogger<LibUsbEventLoop>(),
                 _context
             );
             _eventLoop.Start();
         }
+    }
+
+    /// <inheritdoc/>
+    [Obsolete(
+        "Configure native LogLevel via UsbDotNetOptions when constructing via Usb.Create or DI,"
+            + "and call parameterless Initialize(). This overload will be removed in a future version."
+    )]
+    public void Initialize(LogLevel nativeLibraryLogLevel)
+    {
+        _options.NativeLibraryLogLevel = nativeLibraryLogLevel;
+        Initialize();
     }
 
     private void InitializeLibUsbLogHandler(ISafeContext context, LogLevel logLevel)

--- a/src/UsbDotNet/Usb.cs
+++ b/src/UsbDotNet/Usb.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using UsbDotNet.Core;
@@ -42,76 +41,27 @@ public sealed class Usb : IUsb
     }
 
     /// <summary>
-    /// Creates UsbDotNet with optional LibUsb instance, logging builder, and options.
-    /// Consider using DI; registering via IServiceCollection.AddUsbDotNet() instead.
-    /// <para>NOTE: Call Initialize() before enumerating or opening devices.</para>
-    /// </summary>
-    /// <param name="libUsb">
-    /// Optional libusb instance. If null, a new default instance will be created.
-    /// </param>
-    /// <param name="configureLogging">
-    /// Optional logging builder; e.g. <c>builder =&gt; builder.AddConsole()</c>.
-    /// If null, logging is disabled.
-    /// </param>
-    /// <param name="configureOptions">
-    /// Optional <see cref="UsbDotNetOptions"/> configurator; e.g.
-    /// <c>options =&gt; options.NativeLibraryLogLevel = LogLevel.Information</c>.
-    /// </param>
-    public static Usb Create(
-        ILibUsb? libUsb = null,
-        Action<ILoggingBuilder>? configureLogging = null,
-        Action<UsbDotNetOptions>? configureOptions = null
-    )
-    {
-        var provider = new ServiceCollection()
-            .AddLogging(configureLogging ?? (_ => { }))
-            .BuildServiceProvider();
-        var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-        var options = new UsbDotNetOptions();
-        configureOptions?.Invoke(options);
-        return new Usb(libUsb, loggerFactory, loggerFactory.CreateLogger<Usb>(), options);
-    }
-
-    /// <summary>
-    /// Creates UsbDotNet with all logging disabled.
+    /// Creates UsbDotNet with all logging disabled and default options.
     /// <para>NOTE: Call Initialize() before enumerating or opening devices.</para>
     /// </summary>
     public Usb()
-        : this(
-            libUsb: null,
-            NullLoggerFactory.Instance,
-            NullLogger<Usb>.Instance,
-            new UsbDotNetOptions()
-        ) { }
+        : this(libUsb: null, NullLoggerFactory.Instance, new UsbDotNetOptions()) { }
 
     /// <summary>
-    /// Creates UsbDotNet with optional LibUsb instance and logging.
+    /// Creates UsbDotNet with optional LibUsb instance, logger factory, and options.
     /// <para>NOTE: Call Initialize() before enumerating or opening devices.</para>
+    /// <para>Consider using DI; registered via IServiceCollection.AddUsbDotNet().</para>
     /// </summary>
     /// <param name="libUsb">
     /// Optional libusb instance. If null, a new default instance will be created.
     /// </param>
     /// <param name="loggerFactory">
-    /// Logger factory for libusb logging. If null, logging is disabled.
+    /// Optional logger factory. If null, logging is disabled.
     /// </param>
-    [Obsolete(
-        "Register via IServiceCollection.AddUsbDotNet() or use Usb.Create(...) for non-DI "
-            + "scenarios. This constructor will be removed in a future version."
-    )]
-    public Usb(ILibUsb? libUsb = default, ILoggerFactory? loggerFactory = null)
-        : this(
-            libUsb,
-            loggerFactory ?? NullLoggerFactory.Instance,
-            (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<Usb>(),
-            new UsbDotNetOptions()
-        ) { }
-
-    internal Usb(
-        ILibUsb? libUsb,
-        ILoggerFactory loggerFactory,
-        ILogger<Usb> logger,
-        UsbDotNetOptions options
-    )
+    /// <param name="options">
+    /// Optional <see cref="UsbDotNetOptions"/>. If null, default options are used.
+    /// </param>
+    public Usb(ILibUsb? libUsb, ILoggerFactory? loggerFactory, UsbDotNetOptions? options)
     {
         if (Interlocked.CompareExchange(ref _instances, 1, 0) != 0)
         {
@@ -122,9 +72,9 @@ public sealed class Usb : IUsb
         try
         {
             _libUsb = libUsb ?? new LibUsb();
-            _loggerFactory = loggerFactory;
-            _logger = logger;
-            _options = options;
+            _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+            _logger = _loggerFactory.CreateLogger<Usb>();
+            _options = options ?? new UsbDotNetOptions();
             LibUsbLogHandler.SetLogger(_logger);
         }
         catch (Exception)
@@ -159,8 +109,8 @@ public sealed class Usb : IUsb
 
     /// <inheritdoc/>
     [Obsolete(
-        "Configure native LogLevel via UsbDotNetOptions when constructing via Usb.Create or DI,"
-            + "and call parameterless Initialize(). This overload will be removed in a future version."
+        "Configure native LogLevel via UsbDotNetOptions when using constructor or DI, and "
+            + "call parameterless Initialize(). This overload will be removed in a future version."
     )]
     public void Initialize(LogLevel nativeLibraryLogLevel)
     {

--- a/src/UsbDotNet/Usb.cs
+++ b/src/UsbDotNet/Usb.cs
@@ -61,7 +61,11 @@ public sealed class Usb : IUsb
     /// <param name="options">
     /// Optional <see cref="UsbDotNetOptions"/>. If null, default options are used.
     /// </param>
-    public Usb(ILibUsb? libUsb, ILoggerFactory? loggerFactory, UsbDotNetOptions? options)
+    public Usb(
+        ILibUsb? libUsb = default,
+        ILoggerFactory? loggerFactory = default,
+        UsbDotNetOptions? options = default
+    )
     {
         if (Interlocked.CompareExchange(ref _instances, 1, 0) != 0)
         {

--- a/src/UsbDotNet/Usb.cs
+++ b/src/UsbDotNet/Usb.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using UsbDotNet.Core;
@@ -40,8 +41,39 @@ public sealed class Usb : IUsb
     }
 
     /// <summary>
-    /// Creates the Usb wrapper.
-    /// NOTE: Call Initialize() before enumerating or opening devices.
+    /// Creates UsbDotNet with optional LibUsb instance and logging builder.
+    /// Consider using DI; registering via IServiceCollection.AddUsbDotNet() instead.
+    /// <para>NOTE: Call Initialize() before enumerating or opening devices.</para>
+    /// </summary>
+    /// <param name="libUsb">
+    /// Optional libusb instance. If null, a new default instance will be created.
+    /// </param>
+    /// <param name="configureLogging">
+    /// Optional logging builder; e.g. <c>builder =&gt; builder.AddConsole()</c>.
+    /// If null, logging is disabled.
+    /// </param>
+    public static Usb Create(
+        ILibUsb? libUsb = null,
+        Action<ILoggingBuilder>? configureLogging = null
+    )
+    {
+        var provider = new ServiceCollection()
+            .AddLogging(configureLogging ?? (_ => { }))
+            .BuildServiceProvider();
+        var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
+        return new Usb(libUsb, loggerFactory, loggerFactory.CreateLogger<Usb>());
+    }
+
+    /// <summary>
+    /// Creates UsbDotNet with all logging disabled.
+    /// <para>NOTE: Call Initialize() before enumerating or opening devices.</para>
+    /// </summary>
+    public Usb()
+        : this(libUsb: null, NullLoggerFactory.Instance, NullLogger<Usb>.Instance) { }
+
+    /// <summary>
+    /// Creates UsbDotNet with optional LibUsb instance and logging.
+    /// <para>NOTE: Call Initialize() before enumerating or opening devices.</para>
     /// </summary>
     /// <param name="libUsb">
     /// Optional libusb instance. If null, a new default instance will be created.
@@ -49,7 +81,18 @@ public sealed class Usb : IUsb
     /// <param name="loggerFactory">
     /// Logger factory for libusb logging. If null, logging is disabled.
     /// </param>
+    [Obsolete(
+        "Register via IServiceCollection.AddUsbDotNet() or use Usb.Create(...) for non-DI "
+            + "scenarios. This constructor will be removed in a future version."
+    )]
     public Usb(ILibUsb? libUsb = default, ILoggerFactory? loggerFactory = null)
+        : this(
+            libUsb,
+            loggerFactory ?? NullLoggerFactory.Instance,
+            (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<Usb>()
+        ) { }
+
+    internal Usb(ILibUsb? libUsb, ILoggerFactory loggerFactory, ILogger<Usb> logger)
     {
         if (Interlocked.CompareExchange(ref _instances, 1, 0) != 0)
         {
@@ -60,8 +103,8 @@ public sealed class Usb : IUsb
         try
         {
             _libUsb = libUsb ?? new LibUsb();
-            _loggerFactory = loggerFactory ?? new NullLoggerFactory();
-            _logger = _loggerFactory.CreateLogger<Usb>();
+            _loggerFactory = loggerFactory;
+            _logger = logger;
             LibUsbLogHandler.SetLogger(_logger);
         }
         catch (Exception)
@@ -86,7 +129,10 @@ public sealed class Usb : IUsb
             _logger.LogInformation("LibUsb v{LibUsbVersion} initialized.", GetVersion());
 
             InitializeLibUsbLogHandler(_context, nativeLibraryLogLevel);
-            _eventLoop = new LibUsbEventLoop(_loggerFactory, _context);
+            _eventLoop = new LibUsbEventLoop(
+                _loggerFactory.CreateLogger<LibUsbEventLoop>(),
+                _context
+            );
             _eventLoop.Start();
         }
     }

--- a/src/UsbDotNet/UsbDevice.cs
+++ b/src/UsbDotNet/UsbDevice.cs
@@ -230,7 +230,12 @@ public sealed class UsbDevice : IUsbDevice
             // TODO: libusb_set_auto_detach_kernel_driver on Linux?
             var claimedInterface = Handle.ClaimInterface(descriptor.InterfaceNumber);
 
-            var usbInterface = new UsbInterface(_loggerFactory, this, descriptor, claimedInterface);
+            var usbInterface = new UsbInterface(
+                _loggerFactory.CreateLogger<UsbInterface>(),
+                this,
+                descriptor,
+                claimedInterface
+            );
             // No need to check if already added, checked in TryGetValue above
             _claimedInterfaces[descriptor.InterfaceNumber] = usbInterface;
             _logger.LogDebug("Interface {UsbInterface} claimed.", usbInterface);

--- a/src/UsbDotNet/UsbDotNet.csproj
+++ b/src/UsbDotNet/UsbDotNet.csproj
@@ -6,8 +6,12 @@
     </PropertyGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="UsbDotNet.Tests" />
+        <InternalsVisibleTo Include="UsbDotNet.Extensions.Tests" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     </ItemGroup>
     <ItemGroup>

--- a/src/UsbDotNet/UsbDotNetOptions.cs
+++ b/src/UsbDotNet/UsbDotNetOptions.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+namespace UsbDotNet;
+
+/// <summary>
+/// Configuration options for UsbDotNet.
+/// </summary>
+public sealed class UsbDotNetOptions
+{
+    /// <summary>
+    /// The log level forwarded to the native libusb library via <c>LIBUSB_OPTION_LOG_LEVEL</c>.
+    /// Set to <see cref="LogLevel.None"/> to skip registering the libusb log callback.
+    /// Defaults to <see cref="LogLevel.Warning"/>.
+    /// </summary>
+    public LogLevel NativeLibraryLogLevel { get; set; } = LogLevel.Warning;
+}

--- a/src/UsbDotNet/UsbDotNetServiceCollectionExtensions.cs
+++ b/src/UsbDotNet/UsbDotNetServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using UsbDotNet;
+using UsbDotNet.LibUsbNative;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Microsoft.Extensions.DependencyInjection;
+
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+/// <summary>
+/// Extension methods to register UsbDotNet services in an <see cref="IServiceCollection"/>.
+/// </summary>
+public static class UsbDotNetServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="IUsb"/> and a default <see cref="ILibUsb"/> as singletons.
+    /// Loggers for <see cref="Usb"/> and its sub-components are resolved from the
+    /// <see cref="ILoggerFactory"/> registered in the service collection.
+    /// </summary>
+    public static IServiceCollection AddUsbDotNet(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<ILibUsb, LibUsb>();
+        services.TryAddSingleton<IUsb>(sp =>
+        {
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var libUsb = sp.GetRequiredService<ILibUsb>();
+            return new Usb(libUsb, loggerFactory, loggerFactory.CreateLogger<Usb>());
+        });
+        return services;
+    }
+}

--- a/src/UsbDotNet/UsbDotNetServiceCollectionExtensions.cs
+++ b/src/UsbDotNet/UsbDotNetServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class UsbDotNetServiceCollectionExtensions
     /// Registers <see cref="IUsb"/> and a default <see cref="ILibUsb"/> as singletons.
     /// Loggers for <see cref="Usb"/> and its sub-components are resolved from the
     /// <see cref="ILoggerFactory"/> registered in the service collection.
+    /// <para>NOTE: Call IUsb.Initialize() before enumerating or opening devices.</para>
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configure">
@@ -42,7 +43,7 @@ public static class UsbDotNetServiceCollectionExtensions
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
             var libUsb = sp.GetRequiredService<ILibUsb>();
             var options = sp.GetRequiredService<IOptions<UsbDotNetOptions>>().Value;
-            return new Usb(libUsb, loggerFactory, loggerFactory.CreateLogger<Usb>(), options);
+            return new Usb(libUsb, loggerFactory, options);
         });
         return services;
     }

--- a/src/UsbDotNet/UsbDotNetServiceCollectionExtensions.cs
+++ b/src/UsbDotNet/UsbDotNetServiceCollectionExtensions.cs
@@ -32,6 +32,8 @@ public static class UsbDotNetServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        // Ensure ILoggerFactory is resolvable on a bare ServiceCollection; no-op if already added.
+        _ = services.AddLogging();
         _ = services.AddOptions<UsbDotNetOptions>();
         if (configure is not null)
         {

--- a/src/UsbDotNet/UsbDotNetServiceCollectionExtensions.cs
+++ b/src/UsbDotNet/UsbDotNetServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using UsbDotNet;
 using UsbDotNet.LibUsbNative;
 
@@ -18,16 +19,30 @@ public static class UsbDotNetServiceCollectionExtensions
     /// Loggers for <see cref="Usb"/> and its sub-components are resolved from the
     /// <see cref="ILoggerFactory"/> registered in the service collection.
     /// </summary>
-    public static IServiceCollection AddUsbDotNet(this IServiceCollection services)
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">
+    /// Optional configurator for <see cref="UsbDotNetOptions"/>. Equivalent to calling
+    /// <c>services.Configure&lt;UsbDotNetOptions&gt;(configure)</c>.
+    /// </param>
+    public static IServiceCollection AddUsbDotNet(
+        this IServiceCollection services,
+        Action<UsbDotNetOptions>? configure = null
+    )
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        _ = services.AddOptions<UsbDotNetOptions>();
+        if (configure is not null)
+        {
+            _ = services.Configure(configure);
+        }
         services.TryAddSingleton<ILibUsb, LibUsb>();
         services.TryAddSingleton<IUsb>(sp =>
         {
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
             var libUsb = sp.GetRequiredService<ILibUsb>();
-            return new Usb(libUsb, loggerFactory, loggerFactory.CreateLogger<Usb>());
+            var options = sp.GetRequiredService<IOptions<UsbDotNetOptions>>().Value;
+            return new Usb(libUsb, loggerFactory, loggerFactory.CreateLogger<Usb>(), options);
         });
         return services;
     }

--- a/src/UsbDotNet/UsbInterface.cs
+++ b/src/UsbDotNet/UsbInterface.cs
@@ -18,7 +18,6 @@ public sealed class UsbInterface : IUsbInterface
     private const int ReadBufferSize = 32 * 1024;
     private const int WriteBufferSize = 32 * 1024;
 
-    private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<UsbInterface> _logger;
     private readonly UsbDevice _device;
     private readonly IUsbInterfaceDescriptor _descriptor;
@@ -41,7 +40,7 @@ public sealed class UsbInterface : IUsbInterface
     /// <summary>
     /// A type representing a claimed USB interface.
     /// </summary>
-    /// <param name="loggerFactory">An optional logger factory.</param>
+    /// <param name="logger">Logger for this UsbInterface.</param>
     /// <param name="device">The parent USB device.</param>
     /// <param name="descriptor">The USB interface descriptor.</param>
     /// <param name="claimedInterface">A claimed USB device interface.</param>
@@ -53,8 +52,8 @@ public sealed class UsbInterface : IUsbInterface
     /// Optional write endpoint. When nothing is specified and a write operation is attempted,
     /// an attempt is made to pick the first available "output" endpoint for this interface.
     /// </param>
-    public UsbInterface(
-        ILoggerFactory loggerFactory,
+    internal UsbInterface(
+        ILogger<UsbInterface> logger,
         UsbDevice device,
         IUsbInterfaceDescriptor descriptor,
         ISafeDeviceInterface claimedInterface,
@@ -62,8 +61,7 @@ public sealed class UsbInterface : IUsbInterface
         IUsbEndpointDescriptor? writeEndpoint = default
     )
     {
-        _loggerFactory = loggerFactory;
-        _logger = _loggerFactory.CreateLogger<UsbInterface>();
+        _logger = logger;
         _device = device;
         _descriptor = descriptor;
         _claimedInterface = claimedInterface;

--- a/src/UsbDotNet/UsbInterface.cs
+++ b/src/UsbDotNet/UsbInterface.cs
@@ -52,7 +52,7 @@ public sealed class UsbInterface : IUsbInterface
     /// Optional write endpoint. When nothing is specified and a write operation is attempted,
     /// an attempt is made to pick the first available "output" endpoint for this interface.
     /// </param>
-    internal UsbInterface(
+    public UsbInterface(
         ILogger<UsbInterface> logger,
         UsbDevice device,
         IUsbInterfaceDescriptor descriptor,

--- a/tests/UsbDotNet.Extensions.Tests/ControlTransfer/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Extensions.Tests/ControlTransfer/Given_any_USB_device.cs
@@ -22,7 +22,6 @@ public sealed class Given_any_USB_device : IDisposable
         _usb = new Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<Usb>(),
             new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         _usb.Initialize();

--- a/tests/UsbDotNet.Extensions.Tests/ControlTransfer/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Extensions.Tests/ControlTransfer/Given_any_USB_device.cs
@@ -19,7 +19,7 @@ public sealed class Given_any_USB_device : IDisposable
         _libusb = new LibUsb();
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_any_USB_device>();
-        _usb = new Usb(_libusb, _loggerFactory);
+        _usb = new Usb(_libusb, _loggerFactory, _loggerFactory.CreateLogger<Usb>());
         _usb.Initialize(LogLevel.Information);
         _deviceSource = new TestDeviceSource(_logger, _usb);
         _deviceSource.SetPreferredVendorId(0x2BD9);

--- a/tests/UsbDotNet.Extensions.Tests/ControlTransfer/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Extensions.Tests/ControlTransfer/Given_any_USB_device.cs
@@ -19,8 +19,13 @@ public sealed class Given_any_USB_device : IDisposable
         _libusb = new LibUsb();
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_any_USB_device>();
-        _usb = new Usb(_libusb, _loggerFactory, _loggerFactory.CreateLogger<Usb>());
-        _usb.Initialize(LogLevel.Information);
+        _usb = new Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<Usb>(),
+            new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
+        );
+        _usb.Initialize();
         _deviceSource = new TestDeviceSource(_logger, _usb);
         _deviceSource.SetPreferredVendorId(0x2BD9);
     }

--- a/tests/UsbDotNet.Tests/Usb/Given_a_supported_Huddly_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_a_supported_Huddly_USB_device.cs
@@ -20,7 +20,11 @@ public sealed class Given_a_supported_Huddly_USB_device : IDisposable
         _libusb = new LibUsb();
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_a_supported_Huddly_USB_device>();
-        _usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        _usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         try
         {
             _usb.Initialize(LogLevel.Information);

--- a/tests/UsbDotNet.Tests/Usb/Given_a_supported_Huddly_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_a_supported_Huddly_USB_device.cs
@@ -23,11 +23,12 @@ public sealed class Given_a_supported_Huddly_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
+            new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try
         {
-            _usb.Initialize(LogLevel.Information);
+            _usb.Initialize();
             _deviceSource = new TestDeviceSource(_logger, _usb);
             _deviceSource.SetRequiredVendorId(HuddlyVendorId);
             _deviceSource.SetRequiredInterfaceClass(

--- a/tests/UsbDotNet.Tests/Usb/Given_a_supported_Huddly_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_a_supported_Huddly_USB_device.cs
@@ -23,7 +23,6 @@ public sealed class Given_a_supported_Huddly_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
             new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try

--- a/tests/UsbDotNet.Tests/Usb/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_any_USB_device.cs
@@ -21,11 +21,12 @@ public sealed class Given_any_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
+            new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try
         {
-            _usb.Initialize(LogLevel.Information);
+            _usb.Initialize();
             _deviceSource = new TestDeviceSource(_logger, _usb);
             _deviceSource.SetPreferredVendorId(0x2BD9);
         }

--- a/tests/UsbDotNet.Tests/Usb/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_any_USB_device.cs
@@ -18,7 +18,11 @@ public sealed class Given_any_USB_device : IDisposable
         _libusb = new LibUsb();
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_any_USB_device>();
-        _usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        _usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         try
         {
             _usb.Initialize(LogLevel.Information);

--- a/tests/UsbDotNet.Tests/Usb/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_any_USB_device.cs
@@ -21,7 +21,6 @@ public sealed class Given_any_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
             new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try

--- a/tests/UsbDotNet.Tests/Usb/Given_no_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_no_USB_device.cs
@@ -13,6 +13,14 @@ public sealed class Given_no_USB_device : IDisposable
         _loggerFactory = new TestLoggerFactory(output);
     }
 
+    private UsbDotNet.Usb CreateUsb(LogLevel nativeLogLevel = LogLevel.Information) =>
+        new(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
+            new UsbDotNetOptions { NativeLibraryLogLevel = nativeLogLevel }
+        );
+
     [Fact]
     public void GetVersion_returns_a_valid_version_of_at_least_1_0_27()
     {
@@ -24,17 +32,8 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void Creating_two_active_instances_of_the_Usb_type_is_not_allowed()
     {
-        using var usb1 = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
-        var act = () =>
-            new UsbDotNet.Usb(
-                _libusb,
-                _loggerFactory,
-                _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-            );
+        using var usb1 = CreateUsb();
+        var act = () => CreateUsb();
         act.Should()
             .Throw<InvalidOperationException>()
             .WithMessage("Only one instance of the Usb type allowed.");
@@ -43,27 +42,15 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void Creating_a_second_instance_of_the_Usb_type_is_allowed_after_disposal_of_first()
     {
-        var usb1 = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
+        var usb1 = CreateUsb();
         usb1.Dispose();
-        using var usb2 = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
+        using var usb2 = CreateUsb();
     }
 
     [Fact]
     public void Initialize_throws_when_called_a_second_time()
     {
-        using var usb = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
+        using var usb = CreateUsb();
         usb.Initialize();
         var act = () => usb.Initialize();
         act.Should()
@@ -74,11 +61,7 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void GetDeviceList_throws_when_called_without_Initialize()
     {
-        using var usb = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
+        using var usb = CreateUsb();
         var act = () => usb.GetDeviceList();
         act.Should().Throw<InvalidOperationException>();
     }
@@ -86,12 +69,8 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void GetDeviceList_throws_when_called_after_Dispose()
     {
-        using var usb = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
-        usb.Initialize(LogLevel.Information);
+        using var usb = CreateUsb();
+        usb.Initialize();
         usb.Dispose();
         var act = () => usb.GetDeviceList();
         act.Should().Throw<ObjectDisposedException>();
@@ -105,11 +84,7 @@ public sealed class Given_no_USB_device : IDisposable
             "Hotplug only supported on Linux and macOS."
         );
 
-        using var usb = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
+        using var usb = CreateUsb();
         var act = () => usb.RegisterHotplug(vendorId: 0x2BD9);
         act.Should().Throw<InvalidOperationException>();
     }
@@ -122,12 +97,8 @@ public sealed class Given_no_USB_device : IDisposable
             "Hotplug only supported on Linux and macOS."
         );
 
-        using var usb = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
-        usb.Initialize(LogLevel.Information);
+        using var usb = CreateUsb();
+        usb.Initialize();
         var success = usb.RegisterHotplug(vendorId: 0x2BD9);
         success.Should().BeTrue();
     }
@@ -139,12 +110,8 @@ public sealed class Given_no_USB_device : IDisposable
         {
             return;
         }
-        using var usb = new UsbDotNet.Usb(
-            _libusb,
-            _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
-        );
-        usb.Initialize(LogLevel.Information);
+        using var usb = CreateUsb();
+        usb.Initialize();
         var success = usb.RegisterHotplug(vendorId: 0x2BD9);
         success.Should().BeFalse();
     }

--- a/tests/UsbDotNet.Tests/Usb/Given_no_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_no_USB_device.cs
@@ -17,7 +17,6 @@ public sealed class Given_no_USB_device : IDisposable
         new(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
             new UsbDotNetOptions { NativeLibraryLogLevel = nativeLogLevel }
         );
 

--- a/tests/UsbDotNet.Tests/Usb/Given_no_USB_device.cs
+++ b/tests/UsbDotNet.Tests/Usb/Given_no_USB_device.cs
@@ -24,8 +24,17 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void Creating_two_active_instances_of_the_Usb_type_is_not_allowed()
     {
-        using var usb1 = new UsbDotNet.Usb(_libusb, _loggerFactory);
-        var act = () => new UsbDotNet.Usb(_libusb, _loggerFactory);
+        using var usb1 = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
+        var act = () =>
+            new UsbDotNet.Usb(
+                _libusb,
+                _loggerFactory,
+                _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+            );
         act.Should()
             .Throw<InvalidOperationException>()
             .WithMessage("Only one instance of the Usb type allowed.");
@@ -34,15 +43,27 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void Creating_a_second_instance_of_the_Usb_type_is_allowed_after_disposal_of_first()
     {
-        var usb1 = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        var usb1 = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         usb1.Dispose();
-        using var usb2 = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        using var usb2 = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
     }
 
     [Fact]
     public void Initialize_throws_when_called_a_second_time()
     {
-        using var usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        using var usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         usb.Initialize();
         var act = () => usb.Initialize();
         act.Should()
@@ -53,7 +74,11 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void GetDeviceList_throws_when_called_without_Initialize()
     {
-        using var usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        using var usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         var act = () => usb.GetDeviceList();
         act.Should().Throw<InvalidOperationException>();
     }
@@ -61,7 +86,11 @@ public sealed class Given_no_USB_device : IDisposable
     [Fact]
     public void GetDeviceList_throws_when_called_after_Dispose()
     {
-        using var usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        using var usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         usb.Initialize(LogLevel.Information);
         usb.Dispose();
         var act = () => usb.GetDeviceList();
@@ -76,7 +105,11 @@ public sealed class Given_no_USB_device : IDisposable
             "Hotplug only supported on Linux and macOS."
         );
 
-        using var usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        using var usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         var act = () => usb.RegisterHotplug(vendorId: 0x2BD9);
         act.Should().Throw<InvalidOperationException>();
     }
@@ -89,7 +122,11 @@ public sealed class Given_no_USB_device : IDisposable
             "Hotplug only supported on Linux and macOS."
         );
 
-        using var usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        using var usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         usb.Initialize(LogLevel.Information);
         var success = usb.RegisterHotplug(vendorId: 0x2BD9);
         success.Should().BeTrue();
@@ -102,7 +139,11 @@ public sealed class Given_no_USB_device : IDisposable
         {
             return;
         }
-        using var usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        using var usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         usb.Initialize(LogLevel.Information);
         var success = usb.RegisterHotplug(vendorId: 0x2BD9);
         success.Should().BeFalse();

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_a_supported_Huddly_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_a_supported_Huddly_USB_device.cs
@@ -23,7 +23,11 @@ public sealed class Given_a_supported_Huddly_USB_device : IDisposable
         _libusb = new LibUsb();
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_a_supported_Huddly_USB_device>();
-        _usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        _usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         try
         {
             _usb.Initialize(LogLevel.Information);

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_a_supported_Huddly_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_a_supported_Huddly_USB_device.cs
@@ -26,11 +26,12 @@ public sealed class Given_a_supported_Huddly_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
+            new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try
         {
-            _usb.Initialize(LogLevel.Information);
+            _usb.Initialize();
             _deviceSource = new TestDeviceSource(_logger, _usb);
             _deviceSource.SetRequiredVendorId(HuddlyVendorId);
             _deviceSource.SetRequiredInterfaceClass(

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_a_supported_Huddly_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_a_supported_Huddly_USB_device.cs
@@ -26,7 +26,6 @@ public sealed class Given_a_supported_Huddly_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
             new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_a_vendor_class_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_a_vendor_class_USB_device.cs
@@ -20,11 +20,12 @@ public sealed class Given_a_vendor_class_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
+            new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try
         {
-            _usb.Initialize(LogLevel.Information);
+            _usb.Initialize();
             _deviceSource = new TestDeviceSource(_logger, _usb);
             _deviceSource.SetPreferredVendorId(0x2BD9);
             _deviceSource.SetRequiredInterfaceClass(

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_a_vendor_class_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_a_vendor_class_USB_device.cs
@@ -20,7 +20,6 @@ public sealed class Given_a_vendor_class_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
             new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_a_vendor_class_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_a_vendor_class_USB_device.cs
@@ -17,7 +17,11 @@ public sealed class Given_a_vendor_class_USB_device : IDisposable
         _libusb = new LibUsb();
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_a_vendor_class_USB_device>();
-        _usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        _usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         try
         {
             _usb.Initialize(LogLevel.Information);

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_any_USB_device.cs
@@ -21,11 +21,12 @@ public sealed class Given_any_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
+            new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try
         {
-            _usb.Initialize(LogLevel.Information);
+            _usb.Initialize();
             _deviceSource = new TestDeviceSource(_logger, _usb);
             _deviceSource.SetPreferredVendorId(0x2BD9);
         }

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_any_USB_device.cs
@@ -18,7 +18,11 @@ public sealed class Given_any_USB_device : IDisposable
         _libusb = new LibUsb();
         _loggerFactory = new TestLoggerFactory(output);
         _logger = _loggerFactory.CreateLogger<Given_any_USB_device>();
-        _usb = new UsbDotNet.Usb(_libusb, _loggerFactory);
+        _usb = new UsbDotNet.Usb(
+            _libusb,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<UsbDotNet.Usb>()
+        );
         try
         {
             _usb.Initialize(LogLevel.Information);

--- a/tests/UsbDotNet.Tests/UsbDevice/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDevice/Given_any_USB_device.cs
@@ -21,7 +21,6 @@ public sealed class Given_any_USB_device : IDisposable
         _usb = new UsbDotNet.Usb(
             _libusb,
             _loggerFactory,
-            _loggerFactory.CreateLogger<UsbDotNet.Usb>(),
             new UsbDotNetOptions { NativeLibraryLogLevel = LogLevel.Information }
         );
         try

--- a/tests/UsbDotNet.Tests/UsbDotNetServiceCollectionExtensions/Given_no_USB_device.cs
+++ b/tests/UsbDotNet.Tests/UsbDotNetServiceCollectionExtensions/Given_no_USB_device.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace UsbDotNet.Tests.UsbDotNetServiceCollectionExtensions;
+
+public class Given_no_USB_device
+{
+    [Fact]
+    public void AddUsbDotNet_allows_IUsb_to_be_resolved_without_AddLogging()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddUsbDotNet();
+
+        using var provider = services.BuildServiceProvider();
+        var act = () => provider.GetRequiredService<IUsb>();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AddUsbDotNet_registers_IUsb_as_a_singleton()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddUsbDotNet();
+
+        using var provider = services.BuildServiceProvider();
+        var first = provider.GetRequiredService<IUsb>();
+        var second = provider.GetRequiredService<IUsb>();
+
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void AddUsbDotNet_applies_configure_callback_to_UsbDotNetOptions()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddUsbDotNet(o => o.NativeLibraryLogLevel = LogLevel.Debug);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<UsbDotNetOptions>>().Value;
+
+        options.NativeLibraryLogLevel.Should().Be(LogLevel.Debug);
+    }
+}


### PR DESCRIPTION
This PR updates UsbDotNet’s construction and initialization flow to better support Dependency Injection (DI), including options-based configuration and typed logger injection.

**Changes:**
- Added `UsbDotNetOptions` and a DI registration extension `IServiceCollection.AddUsbDotNet(...)`.
- Refactored `Usb`, `LibUsbEventLoop`, and `UsbInterface` to use typed `ILogger<T>` injection and options-driven initialization (with obsolete shims for older APIs).
- Updated test fixtures and added a DI-based sample app demonstrating usage with `Host.CreateApplicationBuilder`.