### PR TITLE
Tag projects as AOT compatible and trimmable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,11 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+        <IsAotCompatible>true</IsAotCompatible>
+        <IsTrimmable>true</IsTrimmable>
+        <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
             <PrivateAssets>all</PrivateAssets>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>net10.0;net8.0;net6.0</TargetFrameworks>
         <Platforms>AnyCPU;x64;arm64</Platforms>
-        <RuntimeIdentifiers>linux-arm64;linux-x64;maccatalyst-arm64;maccatalyst-x64;osx-arm64;osx-x64;win-arm64;win-x64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>linux-arm64;linux-x64;osx-arm64;osx-x64;win-arm64;win-x64</RuntimeIdentifiers>
         <LangVersion>14.0</LangVersion>
         <Authors>Thomas Mittet</Authors>
         <CurrentYear>2026</CurrentYear>

--- a/examples/UsbDotNet.LibUsbNative.DeviceListToJsonSample/Device/SerializationContext.cs
+++ b/examples/UsbDotNet.LibUsbNative.DeviceListToJsonSample/Device/SerializationContext.cs
@@ -1,5 +1,4 @@
-﻿namespace UsbDotNet.LibUsbNative.DeviceListToJsonSample.Device;
+namespace UsbDotNet.LibUsbNative.DeviceListToJsonSample.Device;
 
-[JsonSerializable(typeof(IEnumerable<DeviceInfo>))]
 [JsonSerializable(typeof(DeviceInfo[]))]
 internal sealed partial class SerializationContext : JsonSerializerContext { }

--- a/examples/UsbDotNet.LibUsbNative.DeviceListToJsonSample/Program.cs
+++ b/examples/UsbDotNet.LibUsbNative.DeviceListToJsonSample/Program.cs
@@ -12,8 +12,8 @@ using var deviceList = context.GetDeviceList();
 Console.WriteLine($"Found {deviceList.Count} USB devices:");
 Console.WriteLine(
     JsonSerializer.Serialize(
-        deviceList.Select(d => GetDeviceInfo(d, d.GetDeviceDescriptor())),
-        GetJsonSerializerOptions()
+        deviceList.Select(d => GetDeviceInfo(d, d.GetDeviceDescriptor())).ToArray(),
+        GetJsonSerializerOptions().GetTypeInfo(typeof(DeviceInfo[]))
     )
 );
 

--- a/tests/UsbDotNet.LibUsbNative.Tests/Extensions/DescriptorToJsonExtension/Given_any_USB_device.cs
+++ b/tests/UsbDotNet.LibUsbNative.Tests/Extensions/DescriptorToJsonExtension/Given_any_USB_device.cs
@@ -1,6 +1,5 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using UsbDotNet.LibUsbNative.Extensions;
-using UsbDotNet.LibUsbNative.Structs;
 
 namespace UsbDotNet.LibUsbNative.Tests.Extensions.DescriptorToJsonExtension;
 
@@ -26,7 +25,10 @@ public abstract class Given_any_USB_device(ITestOutputHelper output, ILibUsbApi 
             var json = device.GetActiveConfigDescriptor().ToJson();
             Output.WriteLine(json);
 
-            var deserialized = JsonSerializer.Deserialize<libusb_config_descriptor>(json)!;
+            var deserialized = JsonSerializer.Deserialize(
+                json,
+                LibUsbSerializationContext.Default.libusb_config_descriptor
+            )!;
             deserialized.ToJson().Should().Be(json);
         });
     }
@@ -43,7 +45,10 @@ public abstract class Given_any_USB_device(ITestOutputHelper output, ILibUsbApi 
             var json = device.GetDeviceDescriptor().ToJson();
             Output.WriteLine(json);
 
-            var deserialized = JsonSerializer.Deserialize<libusb_device_descriptor>(json)!;
+            var deserialized = JsonSerializer.Deserialize(
+                json,
+                LibUsbSerializationContext.Default.libusb_device_descriptor
+            )!;
             deserialized.ToJson().Should().Be(json);
         });
     }


### PR DESCRIPTION
This PR updates the solution to be AOT/trimming-friendly (net8+) and adjusts test/sample JSON serialization to use source-generated `System.Text.Json` metadata to avoid trimming/AOT warnings.

**Changes:**
- Mark net8+ targets as AOT-compatible and trimmable via `Directory.Build.props`.
- Update tests to deserialize using `LibUsbSerializationContext` type metadata.
- Update the DeviceListToJson sample to serialize a `DeviceInfo[]` using source-generated type info and align its `JsonSerializerContext`.
- Remove maccatalyst runtime identifiers from the project declaration

**Justification for removing maccatalyst:**
Including maccatalyst causes build failures with trim. Removing maccatalyst RIDs should not affect the NuGet package output, the package always includes native libraries for all platforms.

When setting IsTrimmable=true, the SDK enumerates every RID listed in RuntimeIdentifiers and tries to resolve a Microsoft.NETCore.App runtime pack for each one (to do AOT/trim analysis).

There is no Microsoft.NETCore.App.Runtime.maccatalyst-arm64/-x64 pack. Mac Catalyst is shipped under Microsoft.MacCatalyst.* packs, which only resolve when TargetFramework is net10.0-maccatalyst (not plain net10.0) and the MAUI/iOS workload is installed.