### PR TITLE
Explicitly set VSTHRD101.severity = error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -149,6 +149,7 @@ dotnet_diagnostic.CA2213.severity = error # Disposable fields should be disposed
 # Unhandled enum value warnings only for defined enum values
 dotnet_diagnostic.CS8509.severity = error # switch case handling not exhaustive
 dotnet_diagnostic.VSTHRD100.severity = error # Avoid async void methods
+dotnet_diagnostic.VSTHRD101.severity = error # Avoid unsupported async delegates
 
 # Code Quality warnings
 
@@ -169,8 +170,9 @@ dotnet_diagnostic.CA1724.severity = warning # Type names should not match namesp
 dotnet_diagnostic.CA1805.severity = warning # Do not initialize unnecessarily
 dotnet_diagnostic.CA1815.severity = warning # Override equals and operator equals on value types
 dotnet_diagnostic.CA1820.severity = warning # Test for empty strings using string length
-dotnet_diagnostic.CA1859.severity = warning # Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1849.severity = warning # Call async methods when in an async method
 dotnet_diagnostic.CA1851.severity = warning # Possible multiple enumerations of IEnumerable collection
+dotnet_diagnostic.CA1859.severity = warning # Use concrete types when possible for improved performance
 dotnet_diagnostic.CA2000.severity = warning # Dispose objects before losing scope
 dotnet_diagnostic.CA2201.severity = warning # Do not raise reserved exception types
 dotnet_diagnostic.CA2227.severity = warning # Collection properties should be read only
@@ -186,6 +188,7 @@ dotnet_diagnostic.IDE0044.severity = warning # Add readonly modifier
 dotnet_diagnostic.IDE0054.severity = warning # Use compound assignment
 dotnet_diagnostic.IDE0059.severity = warning # Remove unnecessary value assignment
 dotnet_diagnostic.IDE0065.severity = warning # 'using' directive placement outside_namespace
+dotnet_diagnostic.IDE0130.severity = warning # Namespace does not match folder structure
 dotnet_diagnostic.IDE0161.severity = warning # Use file-scoped namespace
 
 dotnet_separate_import_directive_groups = false:warning


### PR DESCRIPTION
Updates analyzer configuration to enforce safer async patterns and refine a few additional code-quality/style rules.

**Changes:**
- Set `VSTHRD101` severity to `error` to prevent unsupported async delegates.
- Add `CA1849` and `IDE0130` as `warning`-level diagnostics.
- Minor re-ordering in the Code Quality warnings section to keep diagnostics grouped/ordered.